### PR TITLE
Edit form of the lti1.1 without typeid in the mform

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -542,6 +542,13 @@ function local_annoto_coursemodule_standard_elements($formwrapper, $mform) {
      */
     if ($modulename === 'lti') {
         $typeid = $mform->getElementValue('typeid');
+        if (empty($typeid)) {
+            $typeid = $formwrapper->get_current()->typeid;
+        }
+        // TODO: check for better approach 
+        if (empty($typeid) || is_array($typeid)) {
+            return;
+        }
         $lticonfig = lti_get_type_config($typeid);
         $toolurl = $lticonfig['toolurl'];
         $tooldomain = (new moodle_url($toolurl))->get_host();


### PR DESCRIPTION
https://app.clickup.com/t/86bzrcgqt

Form not is working correctly, but competion is not working, no user action will move it to completed, maybe wrong configuration
![image](https://github.com/user-attachments/assets/1271f00d-1240-4d48-a9d4-75335b811c7a)

        // TODO: check for better approach 
        if (empty($typeid) || is_array($typeid)) {
            return;
        }
   Needed because when edit form send, this function is called one more time and typeid is array
![image](https://github.com/user-attachments/assets/a31c0bdb-077e-4cbb-af0d-69be7ff1d091)
