### PR TITLE
MOODLE_500_STABLE local_annoto: Improve plugin functionality and add …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+phpunit.xml
+.phpunit.cache

--- a/lib.php
+++ b/lib.php
@@ -54,29 +54,6 @@ use local_annoto\annoto_completion;
 use local_annoto\annoto_completiondata;
 
 /**
- * Function allows plugins to injecting JS across the site, like analytics.
- *
- */
-function local_annoto_before_footer() {
-    local_annoto_init();
-    return '';
-}
-
-/**
- * Function Insert a chunk of html at the start of the html document.
- * @return string HTML fragment.
- */
-function local_annoto_before_standard_top_of_body_html() {
-    global $PAGE;
-    // Prevent callback loading for all themes except those:.
-    $themes = explode(',', LOCAL_ANNOTO_TOP_OF_BODY_THEMES);
-    if (in_array($PAGE->theme->name, $themes)) {
-        local_annoto_init();
-    }
-    return '';
-}
-
-/**
  * Function init plugin according to the proper environment conditions.
  * @return boolean
  */
@@ -141,11 +118,11 @@ function local_annoto_get_user_token($settings, $courseid) {
         "name" => fullname($USER), // User's fullname in Moodle.
         "email" => $USER->email, // User's email.
         "photoUrl" => is_object($userpictureurl) ? $userpictureurl->out() : '', // User's avatar in Moodle.
-        "iss" => $settings->clientid, // ClientID from global settings.
+        "iss" => $settings->clientid ?? '', // ClientID from global settings.
         "exp" => $expire, // JWT token expiration time.
         "scope" => local_annoto_get_user_scope($settings, $courseid),
     ];
-    $enctoken = \Firebase\JWT\JWT::encode($payload, $settings->ssosecret, 'HS256');
+    $enctoken = \Firebase\JWT\JWT::encode($payload, $settings->ssosecret ?? '', 'HS256');
 
     return $enctoken;
 }
@@ -210,13 +187,21 @@ function local_annoto_has_capability($allowedroles, $courseid, $capability) {
 }
 
 /**
- * Get parameters for Anooto's JS script
- * @param int $courseid the id of the course.
- * @param string $pageurl url of the current page.
- * @param int $modid mod id.
- * @return array
+ * Generate JavaScript parameters for the Annoto plugin.
+ *
+ * This function retrieves and constructs the necessary configuration and context-specific
+ * parameters for the Annoto plugin's client-side integration. It accounts for course settings,
+ * user context, module information, and activity completion requirements where applicable.
+ *
+ * @param int $courseid The course ID for which the JS parameters are being generated.
+ * @param int|null $modid (Optional) The module ID for activity-specific data, or null for course-level data.
+ * @return array An array of parameters for use in Annoto's JavaScript client.
+ *
+ * @see    local_annoto_get_user_scope()
+ * @see    local_annoto_get_user_token()
+ * @see    local_annoto_get_deployment_domain()
  */
-function local_annoto_get_jsparam($courseid, $modid) {
+function local_annoto_get_jsparam(int $courseid, ?int $modid = null) {
     global $CFG;
     global $USER;
     $course = get_course($courseid);
@@ -264,7 +249,7 @@ function local_annoto_get_jsparam($courseid, $modid) {
     $jsparams = [
         'deploymentDomain' => local_annoto_get_deployment_domain(),
         'bootstrapUrl' => $settings->scripturl,
-        'clientId' => $settings->clientid,
+        'clientId' => $settings->clientid ?? '',
         'userToken' => local_annoto_get_user_token($settings, $courseid),
         'loginUrl' => $loginurl,
         'logoutUrl' => $logouturl,

--- a/tests/get_jsparam_test.php
+++ b/tests/get_jsparam_test.php
@@ -1,0 +1,243 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * local_annoto
+ *
+ * @package    local_annoto
+ * @copyright  2025 Avi Levy <avi@sysbind.co.il>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_annoto;
+
+/**
+ * Unit tests for the local_annoto_get_jsparam function and related functionality.
+ *
+ * @group local_annoto
+ */
+final class get_jsparam_test extends \advanced_testcase {
+    /** @var \stdClass $course Test course. */
+    private $course;
+
+    /**
+     * Standard setup for tests.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+
+        // Create a basic course used by tests.
+        $this->course = self::getDataGenerator()->create_course([
+            'fullname' => 'Annoto Test Course',
+            'summary' => 'Annoto course summary',
+        ]);
+
+        // Ensure $PAGE has a context (needed by user token/picture generation).
+        global $PAGE;
+        $PAGE->set_context(\context_system::instance());
+
+        // Sensible defaults for plugin config used by jsparam.
+        $this->configure_plugin([
+            'scripturl' => 'https://cdn.annoto.example/bootstrap.js',
+            'clientid' => 'client-xyz',
+            'locale' => 0,
+            'activitycompletion' => 0,
+            'moderatorroles' => '',
+        ]);
+    }
+
+    /**
+     * Helper: set multiple plugin configs for local_annoto.
+     *
+     * @param array $values key => value
+     * @return void
+     */
+    private function configure_plugin(array $values): void {
+        foreach ($values as $k => $v) {
+            \set_config($k, $v, 'local_annoto');
+        }
+    }
+
+    /**
+     * Test to ensure a guest user has expected default configuration without providing a cmid.
+     *
+     * This test verifies that:
+     * - The basic configuration values are passed through correctly.
+     * - Guest users have no token, standard user scope, and no enrolment.
+     * - Course metadata (id, fullname, summary) is returned correctly.
+     * - No cmid is provided and locale is disabled.
+     * - Login/logout URLs are properly set.
+     * - The deployment domain matches the expected helper value.
+     * - Moodle version and release information are properly passed through.
+     * - Activity completion is disabled and untouched by default.
+     *
+     * @covers \local_annoto_get_jsparam
+     * @covers \local_annoto_get_deployment_domain
+     */
+    public function test_guest_user_has_expected_defaults_without_cmid(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        // Ensure guest (not-logged-in).
+        $this->setUser(0);
+
+        $params = \local_annoto_get_jsparam($this->course->id, null);
+
+        // Basic config passthrough.
+        $this->assertSame('https://cdn.annoto.example/bootstrap.js', $params['bootstrapUrl']);
+        $this->assertSame('client-xyz', $params['clientId']);
+
+        // Token & scope for guest.
+        $this->assertSame('', $params['userToken']);
+        $this->assertSame('user', $params['userScope']);
+
+        // Enrolment false for guest.
+        $this->assertFalse($params['userIsEnrolled']);
+
+        // Group and course metadata.
+        $this->assertSame((int)$this->course->id, $params['mediaGroupId']);
+        $this->assertSame($this->course->fullname, $params['mediaGroupTitle']);
+        $this->assertSame($this->course->summary, $params['mediaGroupDescription']);
+
+        // No cmid provided.
+        $this->assertNull($params['cmid']);
+
+        // Locale disabled returns boolean false.
+        $this->assertFalse($params['locale']);
+
+        // Login / logout URLs.
+        $this->assertSame($CFG->wwwroot . '/login/index.php', $params['loginUrl']);
+        $this->assertStringStartsWith($CFG->wwwroot . '/login/logout.php', $params['logoutUrl']);
+
+        // Deployment domain equals helper value.
+        $this->assertSame(\local_annoto_get_deployment_domain(), $params['deploymentDomain']);
+
+        // Moodle version info passthrough.
+        $this->assertSame($CFG->version, $params['moodleVersion']);
+        $this->assertSame($CFG->release, $params['moodleRelease']);
+
+        // Activity completion untouched/disabled by default.
+        $this->assertFalse($params['activityCompletionEnabled']);
+        $this->assertNull($params['activityCompletionReq']);
+    }
+
+    /**
+     * Test that a logged-in and enrolled user with locale enabled
+     * receives the correct parameters including locale and token.
+     *
+     * @covers \local_annoto_get_jsparam
+     */
+    public function test_logged_in_enrolled_user_locale_enabled(): void {
+        global $CFG, $DB;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        // Enable locale.
+        $this->configure_plugin(['locale' => 1]);
+
+        // Create & enrol user.
+        $user = self::getDataGenerator()->create_user();
+        self::getDataGenerator()->enrol_user($user->id, $this->course->id);
+        $this->setUser($user);
+
+        // Set a course language explicitly.
+        $DB->set_field('course', 'lang', 'he', ['id' => $this->course->id]);
+
+        $params = \local_annoto_get_jsparam($this->course->id, null);
+
+        // Enrolled user must be detected and receive token.
+        $this->assertTrue($params['userIsEnrolled']);
+        $this->assertNotSame('', $params['userToken']);
+        $this->assertSame('user', $params['userScope']);
+
+        // Locale equals course language when enabled.
+        $this->assertSame('he', $params['locale']);
+    }
+
+    /**
+     * Test that with the CMID provided, media fields are set properly
+     * and activity completion defaults are applied accordingly.
+     *
+     * @covers \local_annoto_get_jsparam
+     */
+    public function test_with_cmid_sets_media_fields_and_completion_defaults(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        // Logged-in user (no specific permissions needed).
+        $user = self::getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Create a simple core module instance in the course (page).
+        $page = self::getDataGenerator()->create_module('page', [
+            'course' => $this->course->id,
+            'name' => 'Annoto Test Page',
+            'intro' => 'Intro text for Annoto page.',
+        ]);
+
+        // Ensure activitycompletion config is enabled but no records exist → should remain disabled in params.
+        $this->configure_plugin(['activitycompletion' => 1]);
+
+        $params = \local_annoto_get_jsparam($this->course->id, $page->cmid);
+
+        // CMID and media fields.
+        $this->assertSame($page->cmid, $params['cmid']);
+        $this->assertSame('Annoto Test Page', $params['mediaTitle']);
+        $this->assertIsString($params['mediaDescription']);
+
+        // Activity completion should still be disabled with no completion record.
+        $this->assertFalse($params['activityCompletionEnabled']);
+        $this->assertNull($params['activityCompletionReq']);
+    }
+
+    /**
+     * Test that a moderator role sets user scope to 'super-mod'
+     * and ensures enrolment is true.
+     *
+     * This test verifies the behavior when a user is assigned
+     * a role with the `local/annoto:moderatediscussion` capability
+     * and enrolled in a course.
+     *
+     * @covers \local_annoto_get_jsparam
+     */
+    public function test_moderator_role_sets_super_mod_and_enrolment_true(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        $user = self::getDataGenerator()->create_user();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Grant the moderator capability to the role and assign in course.
+        \assign_capability('local/annoto:moderatediscussion', CAP_ALLOW, $roleid, \context_system::instance());
+        $coursecontext = \context_course::instance($this->course->id);
+        \role_assign($roleid, $user->id, $coursecontext->id);
+
+        // Enrol user to make sure userIsEnrolled = true.
+        self::getDataGenerator()->enrol_user($user->id, $this->course->id);
+
+        // Mark the role id as allowed moderator role in config.
+        $this->configure_plugin(['moderatorroles' => (string)$roleid]);
+
+        // Login after role/cap changes so session reflects permissions.
+        $this->setUser($user);
+
+        $params = \local_annoto_get_jsparam($this->course->id, null);
+
+        $this->assertSame('super-mod', $params['userScope']);
+        $this->assertTrue($params['userIsEnrolled']);
+        $this->assertNotSame('', $params['userToken']);
+    }
+}

--- a/tests/get_user_token_test.php
+++ b/tests/get_user_token_test.php
@@ -1,0 +1,194 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_annoto;
+
+/**
+ * Tests for local_annoto_get_user_token.
+ *
+ * @package    local_annoto
+ * @copyright  2025 Avi Levy <avi@sysbind.co.il>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Unit tests for local_annoto_get_user_token functionality.
+ *
+ * @covers ::local_annoto_get_user_token
+ * @covers ::local_annoto_get_user_scope
+ * @covers ::local_annoto_has_capability
+ */
+final class get_user_token_test extends \advanced_testcase {
+    /** @var stdClass $course Test course. */
+    private $course;
+
+    /**
+     * Standard setup.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+
+        // Create a basic course used by tests.
+        $this->course = self::getDataGenerator()->create_course();
+
+        // Ensure $PAGE has a context to generate user pictures.
+        global $PAGE;
+        $PAGE->set_context(\context_system::instance());
+    }
+
+    /**
+     * Helper to decode a JWT payload without verifying signature.
+     *
+     * @param string $jwt The encoded token.
+     * @return array Decoded payload as associative array.
+     */
+    private static function decode_jwt_payload(string $jwt): array {
+        $parts = explode('.', $jwt);
+        if (count($parts) < 2) {
+            return [];
+        }
+        $payloadb64 = $parts[1];
+        $payloadb64 = strtr($payloadb64, '-_', '+/');
+        $padding = strlen($payloadb64) % 4;
+        if ($padding > 0) {
+            $payloadb64 .= str_repeat('=', 4 - $padding);
+        }
+        $json = base64_decode($payloadb64);
+        $data = json_decode((string)$json, true);
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * Tests that an empty string is returned when the user is not logged in.
+     *
+     * @covers \local_annoto_get_user_token
+     */
+    public function test_returns_empty_string_when_user_not_logged_in(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        // Ensure not logged in.
+        $this->setUser(0);
+
+        $settings = (object) [
+            'clientid' => 'cid',
+            'ssosecret' => 'secret',
+            'moderatorroles' => '',
+        ];
+
+        $token = local_annoto_get_user_token($settings, $this->course->id);
+        $this->assertSame('', $token);
+    }
+
+    /**
+     * Test that the token contains the expected claims for a regular user.
+     *
+     * This test verifies:
+     * - Token generation for a logged-in user.
+     * - Decodability of the token payload.
+     * - Presence and correctness of basic identity claims (jti, name, email).
+     * - Correct issuer and scope of the token (regular user scope).
+     * - Proper expiration time within approximately 20 minutes.
+     * - Presence and type of the photo URL in the token payload.
+     *
+     * @covers ::local_annoto_get_user_token
+     * @covers ::fullname
+     * @covers ::self::decode_jwt_payload
+     */
+    public function test_token_contains_expected_claims_for_regular_user(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        $user = self::getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        $settings = (object) [
+            'clientid' => 'client123',
+            'ssosecret' => 'topsecret',
+            // Empty allowed roles → user should NOT be moderator.
+            'moderatorroles' => '',
+        ];
+
+        $before = time();
+        $token = local_annoto_get_user_token($settings, $this->course->id);
+        $after = time();
+
+        $this->assertNotEmpty($token, 'Token should be generated for logged-in user.');
+
+        $payload = self::decode_jwt_payload($token);
+        $this->assertNotEmpty($payload, 'Payload should be decodable.');
+
+        // Basic identity claims.
+        $this->assertEquals($user->id, $payload['jti']);
+        $this->assertEquals(fullname($user), $payload['name']);
+        $this->assertEquals($user->email, $payload['email']);
+
+        // Issuer and scope.
+        $this->assertEquals('client123', $payload['iss']);
+        $this->assertEquals('user', $payload['scope']);
+
+        // Expiration approximately 20 minutes ahead.
+        $this->assertGreaterThanOrEqual($before + 60 * 19, $payload['exp']);
+        $this->assertLessThanOrEqual($after + 60 * 21, $payload['exp']);
+
+        // Photo URL should be a string (may be empty on some setups, but usually present).
+        $this->assertArrayHasKey('photoUrl', $payload);
+        $this->assertIsString($payload['photoUrl']);
+    }
+
+    /**
+     * Tests that the token scope is set to 'super-mod' for a user with moderator permissions.
+     *
+     * This test verifies the functionality of the `local_annoto_get_user_token` function
+     * by checking the generated token's payload scope for a user assigned a moderator role.
+     *
+     * @covers ::local_annoto_get_user_token
+     * @covers ::decode_jwt_payload
+     */
+    public function test_token_scope_is_super_mod_for_moderator(): void {
+        global $CFG;
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+
+        // Create a user and a role that will be allowed to moderate.
+        $user = self::getDataGenerator()->create_user();
+        $roleid = self::getDataGenerator()->create_role();
+
+        $coursecontext = \context_course::instance($this->course->id);
+
+        // Assign the role to the user in course context.
+        role_assign($roleid, $user->id, $coursecontext->id);
+
+        // Explicitly allow the capability for this role (system context is fine for tests).
+        assign_capability('local/annoto:moderatediscussion', CAP_ALLOW, $roleid, \context_system::instance());
+
+        // Login as the user AFTER role/cap changes to ensure session reflects permissions.
+        $this->setUser($user);
+
+        // Settings: mark the role as allowed moderator role.
+        $settings = (object) [
+            'clientid' => 'client123',
+            'ssosecret' => 'topsecret',
+            'moderatorroles' => (string)$roleid,
+        ];
+
+        $token = local_annoto_get_user_token($settings, $this->course->id);
+        $this->assertNotEmpty($token);
+
+        $payload = self::decode_jwt_payload($token);
+        $this->assertEquals('super-mod', $payload['scope']);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-
-$plugin->version   = 2025060800;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release  = '5.4.0';
-$plugin->requires  = 2021051700;        // Requires this Moodle version 3.11/recent patch of 3.9.
+$plugin->version = 2025060800;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release = '5.4.0';
+$plugin->requires = 2025041403;        // Requires this Moodle version 3.11/recent patch of 3.9.
 $plugin->component = 'local_annoto';    // Full name of the plugin (used for diagnostics).
+$plugin->supported = [500, 500];


### PR DESCRIPTION
During testing and instllation on Moodle 5.0.X with php 8.4 we got some wornings:  (see attached image)
<img width="2929" height="1430" alt="Screenshot From 2025-11-26 12-30-16" src="https://github.com/user-attachments/assets/0fa8fb5e-e61f-40f1-ab17-846122f16420" />

In addition all behat test using javascript in moodle is fail due to some error of undifind parmaters.


Refactored methods to simplify structure, added null coalescing for safer defaults, and removed unused callbacks for clarity. Introduced detailed type hints and updated the plugin's required Moodle version to ensure compatibility.

Added unit tests to verify functionality of `get_jsparam` and `get_user_token` methods, ensuring robustness. These changes enhance plugin maintainability and guarantee consistent behavior.

##note
Please consider also open different branch to each Moodle stable version, this one is for MOODLE_500_STABLE