### PR TITLE
fix: add namespace prefix to global COMPLETION_TRACKING_NONE constant to use global namespace instead of local_annoto

### DIFF
--- a/classes/admin_setting_custompickroles.php
+++ b/classes/admin_setting_custompickroles.php
@@ -81,7 +81,7 @@ class local_annoto_admin_setting_custompickroles extends admin_setting_configmul
         global $CFG;
 
         if (during_initial_install()) {
-            return null;
+            return [];
         }
         $result = [];
         foreach ($this->types as $archetype) {

--- a/classes/completion.php
+++ b/classes/completion.php
@@ -43,7 +43,7 @@ class annoto_completion extends persistent {
     /**
      * Completion tracking none constant.
      */
-    const COMPLETION_TRACKING_NONE = COMPLETION_TRACKING_NONE;
+    const COMPLETION_TRACKING_NONE = \COMPLETION_TRACKING_NONE;
 
     /**
      * Completion tracking automatic constant.

--- a/classes/task/completion.php
+++ b/classes/task/completion.php
@@ -121,15 +121,15 @@ class completion extends \core\task\scheduled_task {
                 // var_export($totalviewcompleted, true) . ' comments: ' . var_export($commentscompleted, true) .
                 // ' replies: ' . var_export($repliescompleted, true));.
 
-                if ($completed && $completionstate <= COMPLETION_INCOMPLETE) {
+                if ($completed && $completionstate <= \COMPLETION_INCOMPLETE) {
                     // TRACE: mtrace('AnnotoCompletionTask: Updating completion state for user '
                     // . $userid . ' to COMPLETION_COMPLETE');.
-                    $completion->update_state($cm, COMPLETION_COMPLETE, $userid);
-                } else if (!$completed && $completionstate > COMPLETION_INCOMPLETE) {
+                    $completion->update_state($cm, \COMPLETION_COMPLETE, $userid);
+                } else if (!$completed && $completionstate > \COMPLETION_INCOMPLETE) {
                     // TRACE: mtrace('AnnotoCompletionTask: Updating completion
                     // state for user ' . $userid . ' to COMPLETION_INCOMPLETE');.
                     // Need to set override param to true, otherwise completion will not be updated.
-                    $completion->update_state($cm, COMPLETION_INCOMPLETE, $userid, true);
+                    $completion->update_state($cm, \COMPLETION_INCOMPLETE, $userid, true);
                 }
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -78,7 +78,7 @@ function local_annoto_before_standard_top_of_body_html() {
 
 /**
  * Function init plugin according to the proper environment conditions.
- * @return boolean
+ * @return void
  */
 function local_annoto_init() {
     global $PAGE, $COURSE;


### PR DESCRIPTION
fixes Undefined constant "local_annoto\COMPLETION_TRACKING_NONE" on user_enrolment_deleted