### PR TITLE
Fix use of undefined settings property.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -141,11 +141,11 @@ function local_annoto_get_user_token($settings, $courseid) {
         "name" => fullname($USER), // User's fullname in Moodle.
         "email" => $USER->email, // User's email.
         "photoUrl" => is_object($userpictureurl) ? $userpictureurl->out() : '', // User's avatar in Moodle.
-        "iss" => $settings->clientid, // ClientID from global settings.
+        "iss" => $settings->clientid ?? '', // ClientID from global settings.
         "exp" => $expire, // JWT token expiration time.
         "scope" => local_annoto_get_user_scope($settings, $courseid),
     ];
-    $enctoken = \Firebase\JWT\JWT::encode($payload, $settings->ssosecret, 'HS256');
+    $enctoken = \Firebase\JWT\JWT::encode($payload, $settings->ssosecret ?? '', 'HS256');
 
     return $enctoken;
 }
@@ -263,8 +263,8 @@ function local_annoto_get_jsparam($courseid, $modid) {
 
     $jsparams = [
         'deploymentDomain' => local_annoto_get_deployment_domain(),
-        'bootstrapUrl' => $settings->scripturl,
-        'clientId' => $settings->clientid,
+        'bootstrapUrl' => $settings->scripturl ?? '',
+        'clientId' => $settings->clientid ?? '',
         'userToken' => local_annoto_get_user_token($settings, $courseid),
         'loginUrl' => $loginurl,
         'logoutUrl' => $logouturl,


### PR DESCRIPTION
When running Behat test for some component with the site having annoto installed as well, test fail because of the use of an undefined $settings property by annoto.
This is probably, because the annoto plugin does not define default settings when the setup is run.

The database did not return any rows when running:

```
select * from mdl_config_plugins where plugin = 'local_annoto';
```

Error output when running a test (here for the qtype_kprime plugin) looks like this:

```
005 Scenario: Testcase 10, 11 for Moodle ≤ 4.5 # /selenium/moodle-5011/public/question/type/kprime/tests/behat/03.feature:37
      And I am on "Course 1" course homepage   # /selenium/moodle-5011/public/question/type/kprime/tests/behat/03.feature:32
        Exception: Moodle exception: Exception - Warning: Undefined property: stdClass::$clientid in [dirroot]/local/annoto/lib.php on line 266 File: /public/lib/behat/lib.php Line: 156 Stack trace: Error code: generalexceptionmessage * line 156 of /public/lib/behat/lib.php: Exception thrown
* line 266 of  /public/local/annoto/lib.php: call to behat_error_handler() * line 87 of /public/local/annoto/externallib.php: call to local_annoto_get_jsparam()
* line 0 of unknownfile: call to local_annoto_external::get_jsparams() * line 253 of /public/lib/external/classes/external_api.php: call to call_user_func_array()
* line 83 of /public/lib/ajax/service.php: call to core_external\external_api::call_external_function()
        Exception - Warning: Undefined property: stdClass::$clientid in [dirroot]/local/annoto/lib.php on line 266 in /selenium/moodle-5011/public/lib/behat/classes/behat_session_trait.php:984
```

The patch in this PR just uses the default annotation using an empty string when the property is not defined.