### PR TITLE
Handle unconfigured settings gracefully in token generation

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -127,6 +127,16 @@ function local_annoto_get_user_token($settings, $courseid) {
         return '';
     }
 
+    // Skip token generation when the plugin is not fully configured (no client id or SSO
+    // secret). This avoids signing a JWT with an empty secret and prevents PHP warnings on
+    // every page when Annoto has not been set up yet - e.g. during Behat runs of other
+    // plugins. empty() is null- and undefined-property-safe, so it does not warn itself.
+    if (empty($settings->clientid) || empty($settings->ssosecret)) {
+        debugging('local_annoto: clientid or ssosecret is not configured, skipping user token generation.',
+            DEBUG_DEVELOPER);
+        return '';
+    }
+
     // Provide page and js with data.
     // Get user's avatar.
     $userpicture = new user_picture($USER);
@@ -265,7 +275,7 @@ function local_annoto_get_jsparam($courseid, $modid) {
         'deploymentDomain' => local_annoto_get_deployment_domain(),
         'bootstrapUrl' => $settings->scripturl,
         'annotoMoodleCdnUrl' => $settings->moodlejsurl,
-        'clientId' => $settings->clientid,
+        'clientId' => $settings->clientid ?? '',
         'userToken' => local_annoto_get_user_token($settings, $courseid),
         'loginUrl' => $loginurl,
         'logoutUrl' => $logouturl,

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -1,0 +1,116 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for local_annoto lib functions.
+ *
+ * @package    local_annoto
+ * @copyright  Annoto Ltd.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_annoto;
+
+/**
+ * Tests for token generation helpers in lib.php.
+ *
+ * @package    local_annoto
+ * @copyright  Annoto Ltd.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class lib_test extends \advanced_testcase {
+
+    /**
+     * Load the global functions under test.
+     */
+    public static function setUpBeforeClass(): void {
+        global $CFG;
+        parent::setUpBeforeClass();
+        require_once($CFG->dirroot . '/local/annoto/lib.php');
+    }
+
+    /**
+     * A logged-in user with no client id / SSO secret configured must not produce a
+     * token, and must not raise PHP warnings (the plugin is simply not set up yet).
+     *
+     * @covers ::local_annoto_get_user_token
+     * @dataProvider unconfigured_settings_provider
+     * @param array $settings partial settings that are missing clientid and/or ssosecret
+     */
+    public function test_get_user_token_empty_when_not_configured(array $settings): void {
+        $this->resetAfterTest();
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        $token = local_annoto_get_user_token((object)$settings, 0);
+
+        $this->assertSame('', $token);
+        $this->assertDebuggingCalled();
+    }
+
+    /**
+     * Data provider covering each unconfigured permutation: nothing set, only clientid,
+     * only ssosecret, and an explicit null value.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function unconfigured_settings_provider(): array {
+        return [
+            'both missing' => [[]],
+            'only clientid set' => [['clientid' => 'abc']],
+            'only ssosecret set' => [['ssosecret' => 'topsecret']],
+            'explicit nulls' => [['clientid' => null, 'ssosecret' => null]],
+            'empty strings' => [['clientid' => '', 'ssosecret' => '']],
+        ];
+    }
+
+    /**
+     * A not-logged-in user always gets an empty token, before any settings are read.
+     *
+     * @covers ::local_annoto_get_user_token
+     */
+    public function test_get_user_token_empty_when_not_logged_in(): void {
+        $this->resetAfterTest();
+        $this->setUser(null);
+
+        $this->assertSame('', local_annoto_get_user_token((object)[], 0));
+    }
+
+    /**
+     * When both client id and SSO secret are set, a signed JWT is returned unchanged.
+     *
+     * @covers ::local_annoto_get_user_token
+     */
+    public function test_get_user_token_generated_when_configured(): void {
+        $this->resetAfterTest();
+        $course = $this->getDataGenerator()->create_course();
+        $user = $this->getDataGenerator()->create_and_enrol($course, 'student');
+        $this->setUser($user);
+
+        $settings = (object)[
+            'clientid' => 'client-123',
+            'ssosecret' => 'super-secret-value',
+            'moderatorroles' => 'manager,editingteacher',
+        ];
+
+        $token = local_annoto_get_user_token($settings, $course->id);
+
+        $this->assertIsString($token);
+        $this->assertNotEmpty($token);
+        // A JWT has three dot-separated segments (header.payload.signature).
+        $this->assertCount(3, explode('.', $token));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$plugin->version   = 2026072800;        // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release  = '5.5.0';
+$plugin->version   = 2026080200;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release  = '5.5.1';
 $plugin->requires  = 2021051700;        // Requires this Moodle version 3.11/recent patch of 3.9.
 $plugin->supported = [311, 502];        // Supported from Moodle 3.11 (311) up to Moodle 5.2 (502).
 $plugin->component = 'local_annoto';    // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
## Summary

Hardens `local_annoto_get_user_token` against the "plugin installed but not configured" state, fixing the PHP warnings that leak into unrelated plugins' Behat runs (#173). This is an alternative to #174 that also addresses the review feedback on that PR.

When Annoto is installed but not set up, `clientid` and `ssosecret` are declared with a `null` default in `settings.php`, so they are never written to config and remain **undefined**. Under PHP 8.x:
- reading `$settings->clientid` / `$settings->ssosecret` raises an *undefined property* warning, and
- passing the null secret into `JWT::encode()` → `hash_hmac()` raises a *null-to-string* deprecation.

Because Annoto loads on every page, these surfaced during the Behat runs of other plugins (e.g. `tool_certificate` on Moodle 5.2 / PHP 8.4).

## What changed

- **`lib.php` — early return when unconfigured.** Instead of signing a JWT with an empty secret (which silently masks a real misconfiguration on production sites), `local_annoto_get_user_token` now returns `''` and emits a `DEBUG_DEVELOPER` note when `clientid` or `ssosecret` is missing. `empty()` is null- and undefined-property-safe, so the guard itself never warns.
- **`lib.php` — defensive `?? ''`** on the `clientId` JS param, since it is emitted independently of the token.
- **`tests/lib_test.php`** — new PHPUnit coverage for the unconfigured (5 permutations), not-logged-in, and fully-configured paths.
- **`version.php`** — bumped to `2026080200` / `5.5.1` so the change propagates on upgrade.

## Why not just `?? ''` (as in #174)

`?? ''` silences the warnings but still mints a JWT signed with an empty secret and an empty client id — so a genuinely misconfigured production site fails *silently* instead of loudly. The early return keeps unconfigured sites quiet in Behat while surfacing real misconfigurations via `debugging()`.

## Testing

- `php -l` clean on all changed files.
- New unit tests assert: unconfigured → empty token + `debugging()` called; not logged in → empty token; fully configured → valid 3-segment JWT.

Closes #173